### PR TITLE
Fix SSDP datagram sending

### DIFF
--- a/coherence/upnp/core/ssdp.py
+++ b/coherence/upnp/core/ssdp.py
@@ -238,10 +238,9 @@ class SSDPServer(EventDispatcher, DatagramProtocol, log.LogAble):
         self.info(f'send discovery response delayed by '
                   f'{delay} for {usn} to {destination}')
         try:
-            self.transport.write(
-                to_bytes(response), to_bytes(destination))
+            self.transport.write(to_bytes(response), destination)
         except (AttributeError, socket.error) as msg:
-            self.info(f'failure sending out byebye notification: {msg}')
+            self.exception(f'failure sending out datagram: {msg}')
 
     def discoveryRequest(self, headers, xxx_todo_changeme2):
         '''Process a discovery request.  The response must be sent to


### PR DESCRIPTION
The conversion to_bytes is wrong here. Twisted expects a tuple (IPAddress, Port). The method send_it not only sends byebye notifications but is also used to answer ssdp:discover requests, that is failures to send are more severe.