### PR TITLE
Specify the eventdispatcher version in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ deps = [
     'Twisted >= 18.7',
     'zope.interface',
     'lxml',
-    'eventdispatcher',
+    'eventdispatcher == 1.9.4',
     'python-dateutil',
     'pyopenssl'
 ]


### PR DESCRIPTION
Unfortunately the eventdispatcher project uses an odd version number
sequence, for example `1.81` is older than `1.9.4`. This causes issues
with determining the latest version and can result in non-working
installs.

This version was set to match the version used elsewhere in the project
for testing, although it's possible a wider range would also be valid.

Fixes: #16 