### PR TITLE
Fix missing headers for some devices

### DIFF
--- a/coherence/upnp/devices/media_server.py
+++ b/coherence/upnp/devices/media_server.py
@@ -385,10 +385,10 @@ class MSRoot(resource.Resource, log.LogAble):
                     self.warning(
                         f'{request.method} request with content-length '
                         f'{headers[b"content-length"]} header - sanitizing')
-					# This should fix #20
+                    # Fix missing headers for some Samsung TVs (see issue #20)
                     try:
                         del request.received_headers[b'content-length']
-                    except:
+                    except AttributeError:
                         request.received_headers = headers
                         del request.received_headers[b'content-length']
                 self.debug('data', )

--- a/coherence/upnp/devices/media_server.py
+++ b/coherence/upnp/devices/media_server.py
@@ -385,7 +385,12 @@ class MSRoot(resource.Resource, log.LogAble):
                     self.warning(
                         f'{request.method} request with content-length '
                         f'{headers[b"content-length"]} header - sanitizing')
-                    del request.received_headers[b'content-length']
+					# This should fix #20
+                    try:
+                        del request.received_headers[b'content-length']
+                    except:
+                        request.received_headers = headers
+                        del request.received_headers[b'content-length']
                 self.debug('data', )
                 if len(request.content.getvalue()) > 0:
                     # shall we remove that?


### PR DESCRIPTION
When using the `FSStore` backend (refs #20)

Fixes: #20 
Closes: #23 