### PR TITLE
:bug: Fix events dispatching: `kwargs` should be `args`

### DIFF
--- a/coherence/base.py
+++ b/coherence/base.py
@@ -1038,7 +1038,7 @@ class Coherence(EventDispatcher, log.LogAble):
         )
         self.devices.append(device)
         self.dispatch_event(
-            'coherence_device_detection_completed', device=device
+            'coherence_device_detection_completed', device,
         )
 
     def remove_device(self, device_type, infos):

--- a/coherence/upnp/core/device.py
+++ b/coherence/upnp/core/device.py
@@ -177,15 +177,10 @@ class Device(EventDispatcher, log.LogAble):
                 f'embedded device {self.friendly_name} '
                 + f'{self.device_type} initialized, parent {self.parent}'
             )
-        self.dispatch_event('device_detection_completed', None, device=self)
         if self.parent is not None:
-            self.dispatch_event(
-                'device_detection_completed', self.parent, device=self
-            )
+            self.dispatch_event('device_detection_completed', self.parent)
         else:
-            self.dispatch_event(
-                'device_detection_completed', self, device=self
-            )
+            self.dispatch_event('device_detection_completed', self)
 
     def service_detection_failed(self, device):
         self.remove()
@@ -746,7 +741,7 @@ class RootDevice(Device):
             f'rootdevice {self.friendly_name} {self.st} {self.host} '
             + f'initialized, manifestation {self.manifestation}'
         )
-        self.dispatch_event('root_device_detection_completed', device=self)
+        self.dispatch_event('root_device_detection_completed', self)
 
     def add_device(self, device):
         self.debug(f'RootDevice add_device {device}')

--- a/coherence/upnp/core/service.py
+++ b/coherence/upnp/core/service.py
@@ -592,9 +592,7 @@ class Service(EventDispatcher, log.LogAble):
             # print('service parse:', self, self.device)
             self.detection_completed = True
             self.dispatch_event(
-                'service_detection_completed',
-                sender=self.device,
-                device=self.device,
+                'service_detection_completed', self.device, self.device,
             )
             self.info(
                 f'send signal Coherence.UPnP.Service.detection_'
@@ -611,9 +609,7 @@ class Service(EventDispatcher, log.LogAble):
         def gotError(failure, url):
             self.warning(f'error requesting {url}')
             self.info(f'failure {failure}')
-            self.dispatch_event(
-                'service_detection_failed', self.device, device=self.device
-            )
+            self.dispatch_event('service_detection_failed', self.device)
 
         d = utils.getPage(self.get_scpd_url())
         d.addCallbacks(

--- a/coherence/upnp/devices/control_point.py
+++ b/coherence/upnp/devices/control_point.py
@@ -291,7 +291,11 @@ class ControlPoint(EventDispatcher, log.LogAble):
 
                 device.set_client(client)
 
-        if device.client.detection_completed:
+        if (
+                device.client and
+                hasattr(device.client, 'detection_completed') and
+                device.client.detection_completed
+        ):
             self.completed(device.client)
         self.process_queries(device)
 


### PR DESCRIPTION
Some of the events are emitted as kwargs...but it should be args. The affected events are:
  - `detection_completed`
  - `device_detection_completed`
  - `root_device_detection_completed`
  - `service_detection_failed`